### PR TITLE
mark-devkit: Bump virtual/gsasl-2

### DIFF
--- a/virtual/gsasl/gsasl-2.ebuild
+++ b/virtual/gsasl/gsasl-2.ebuild
@@ -1,0 +1,10 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+
+DESCRIPTION="Virtual for the GNU SASL library"
+SLOT="0"
+KEYWORDS="alpha amd64 arm arm64 hppa ia64 ppc ppc64 s390 sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~x86-macos"
+
+RDEPEND="|| ( net-libs/libgsasl net-misc/gsasl )"


### PR DESCRIPTION
Automatic bump of package virtual/gsasl-2 for branch mark-unstable by mark-bot