### PR TITLE
mark-devkit: Bump app-crypt/pinentry-1.2.1-r1

### DIFF
--- a/app-crypt/pinentry/files/pinentry-gettext-0.26.patch
+++ b/app-crypt/pinentry/files/pinentry-gettext-0.26.patch
@@ -1,0 +1,11 @@
+/configure.ac2022-08-24 10:31:59.000000000 +0000
++++ b/configuregure.ac2025-07-29 05:35:33.991854229 +0000
+@@ -48,6 +48,8 @@
+ AC_CONFIG_AUX_DIR([build-aux])
+   AC_CONFIG_HEADERS([config.h])
+   AC_CONFIG_SRCDIR(pinentry/pinentry.h)
+  +AM_GNU_GETTEXT([external])
+  +AM_GNU_GETTEXT_VERSION(0.24.1)
+   AM_INIT_AUTOMAKE([serial-tests dist-bzip2 no-dist-gzip])
+   
+   AC_USE_SYSTEM_EXTENSIONS

--- a/app-crypt/pinentry/pinentry-1.2.1-r1.ebuild
+++ b/app-crypt/pinentry/pinentry-1.2.1-r1.ebuild
@@ -37,13 +37,15 @@ BDEPEND="
 IDEPEND=">=app-eselect/eselect-pinentry-0.7.2"
 
 DOCS=( AUTHORS ChangeLog NEWS README THANKS TODO )
+PATCHES=(
+	"${FILESDIR}"/files/pinentry-gettext-0.26.patch
+)
 
 src_prepare() {
 	default
 
-	unset FLTK_CONFIG
-
 	eautoreconf
+	elibtoolize
 }
 
 src_configure() {


### PR DESCRIPTION
Automatic bump of package app-crypt/pinentry-1.2.1-r1 for branch mark-iii by mark-bot