### PR TITLE
mark-devkit: [mark-iii] Bump app-crypt/pinentry-1.2.1-r1

### DIFF
--- a/app-crypt/pinentry/files/pinentry-gettext-0.26.patch
+++ b/app-crypt/pinentry/files/pinentry-gettext-0.26.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac	2025-07-30 07:14:45.330251669 -0000
++++ b/configure.ac	2025-07-30 07:15:04.193341794 -0000
+@@ -49,6 +49,8 @@
+ AC_CONFIG_HEADERS([config.h])
+ AC_CONFIG_SRCDIR(pinentry/pinentry.h)
+ AM_INIT_AUTOMAKE([serial-tests dist-bzip2 no-dist-gzip])
++AM_GNU_GETTEXT([external])
++AM_GNU_GETTEXT_VERSION(0.24.1)
+ 
+ AC_USE_SYSTEM_EXTENSIONS
+ 

--- a/app-crypt/pinentry/pinentry-1.2.1-r1.ebuild
+++ b/app-crypt/pinentry/pinentry-1.2.1-r1.ebuild
@@ -31,19 +31,21 @@ RDEPEND="
 	gtk? ( app-crypt/gcr:0[gtk] )
 "
 BDEPEND="
-	sys-devel/gettext
+	>=sys-devel/gettext-0.24.0
 	virtual/pkgconfig
 "
 IDEPEND=">=app-eselect/eselect-pinentry-0.7.2"
 
 DOCS=( AUTHORS ChangeLog NEWS README THANKS TODO )
+PATCHES=(
+	"${FILESDIR}"/pinentry-gettext-0.26.patch
+)
 
 src_prepare() {
 	default
 
-	unset FLTK_CONFIG
-
 	eautoreconf
+	elibtoolize
 }
 
 src_configure() {


### PR DESCRIPTION
Automatic bump of package app-crypt/pinentry-1.2.1-r1 for branch mark-iii by mark-bot