### PR TITLE
mark-devkit: [mark-iii] Bump sys-apps/bolt-0.9.8-r1

### DIFF
--- a/sys-apps/bolt/bolt-0.9.8-r1.ebuild
+++ b/sys-apps/bolt/bolt-0.9.8-r1.ebuild
@@ -15,7 +15,6 @@ IUSE="doc systemd"
 
 DEPEND="
 	>=dev-libs/glib-2.56.0:2
-	dev-util/glib-utils
 	virtual/libudev
 	virtual/udev
 	sys-auth/polkit[introspection]


### PR DESCRIPTION
Automatic bump of package sys-apps/bolt-0.9.8-r1 for branch mark-iii by mark-bot