### PR TITLE
mark-devkit: [mark-iii] Bump app-crypt/gcr-4.4.0.1-r1

### DIFF
--- a/app-crypt/gcr/gcr-4.4.0.1-r1.ebuild
+++ b/app-crypt/gcr/gcr-4.4.0.1-r1.ebuild
@@ -16,7 +16,6 @@ vala? ( introspection )
 "
 BDEPEND="gtk? ( dev-libs/libxml2:2 )
 	dev-util/gdbus-codegen
-	dev-util/glib-utils
 	gtk-doc? ( dev-util/gi-docgen )
 	sys-devel/gettext
 	virtual/pkgconfig


### PR DESCRIPTION
Automatic bump of package app-crypt/gcr-4.4.0.1-r1 for branch mark-iii by mark-bot