### PR TITLE
mark-devkit: [mark-unstable] Bump dev-libs/openssl-1.1.1

### DIFF
--- a/dev-libs/openssl/openssl-1.1.1.ebuild
+++ b/dev-libs/openssl/openssl-1.1.1.ebuild
@@ -1,0 +1,170 @@
+# Distributed under the terms of the GNU General Public License v2
+# Autogen by MARK Devkit
+
+EAPI=7
+
+inherit flag-o-matic toolchain-funcs preserve-libs
+
+DESCRIPTION="TLS/SSL and crypto library"
+HOMEPAGE="https://github.com/openssl/openssl"
+SRC_URI="https://api.github.com/repos/openssl/openssl/tarball/OpenSSL_1_1_1 -> openssl-1.1.1-1708e3e.tar.gz"
+
+LICENSE="Apache-2.0"
+SLOT="0/${PVR}" # Funtoo change -- force more frequent rebuilds.
+KEYWORDS="*"
+# TODO: Add support for fips
+# keep bindist USE for compatibility with older ebuilds until we will migrate to openssl3.
+IUSE="+asm -bindist libc_musl rfc3779 sctp cpu_flags_x86_sse2 weak-ssl-ciphers static-libs +tls-compression tls-heartbeat vanilla"
+RESTRICT=""
+
+# app-misc/c_rehash is deprecated by https://bugs.funtoo.org/browse/FL-10434
+# openssl installs perl version of c_rehash by default
+# openssl also comes with its own C version of rehash, which is now preferred
+# See https://nvd.nist.gov/vuln/detail/CVE-2022-2068 for more details on c_rehash deprecation
+# Ensure we block app-misc/c_rehash for new openssl versions
+RDEPEND="
+	!app-misc/c_rehash
+	tls-compression? ( >=sys-libs/zlib-1.2.8-r1[static-libs(+)] )
+	"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	>=dev-lang/perl-5
+	sctp? ( >=net-misc/lksctp-tools-1.0.12 )
+	"
+PDEPEND="app-misc/ca-certificates"
+PATCHES=(
+	"${FILESDIR}/CVE-2023-5678.patch"
+)
+
+post_src_unpack() {
+	mv openssl-openssl-* ${S}
+}
+
+src_prepare() {
+	# Make sure we only ever touch Makefile.org and avoid patching a file
+	# that gets blown away anyways by the Configure script in src_configure
+	rm -f Makefile
+
+	eapply_user #332661
+
+	rm test/recipes/80-test_ssl_new.t || die
+	rm test/recipes/30-test_afalg.t || die
+
+	default
+}
+
+src_configure() {
+	local _target _optflags
+	SSL_CNF_DIR="/etc/ssl"
+
+	[[ ${CC} == *clang* ]] && append-flags -Qunused-arguments
+
+	append-flags -fno-strict-aliasing
+	append-flags $(test-flags-CC -Wa,--noexecstack)
+	append-cppflags -DOPENSSL_NO_BUF_FREELISTS
+
+	unset APPS
+	unset SCRIPTS
+	unset CROSS_COMPILE
+
+	tc-export AR CC CXX RANLIB RC
+
+	use_ssl() { usex $1 "enable-${2:-$1}" "no-${2:-$1}" " ${*:3}" ; }
+	echoit() { echo "$@" ; "$@" ; }
+
+
+	CARCH=${CHOST%%-*}
+	case "$CARCH" in
+		aarch64*)   _target="linux-aarch64" ;;
+		arm*)       _target="linux-armv4" ;;
+		mips64*)    _target="linux64-mips64" ;;
+		# explicit _optflags is needed to prevent automatic -mips3 addition
+		mips*)      _target="linux-mips32"; _optflags="-mips32" ;;
+		ppc)        _target="linux-ppc" ;;
+		ppc64)      _target="linux-ppc64" ;;
+		ppc64le)    _target="linux-ppc64le" ;;
+ 		x86)        _target="linux-elf" ;;
+		x86_64)     _target="linux-x86_64"; _optflags="enable-ec_nistp_64_gcc_128" ;;
+		s390x)      _target="linux64-s390x";;
+		riscv64)    _target="linux64-riscv64";;
+ 		loongarch64)_target="linux64-loongarch64";;
+ 		*)          die "Unable to determine architecture from (arch=$CARCH)" ;;
+ 	esac
+
+	CFLAGS= LDFLAGS= echoit \
+	perl ./Configure \
+		${_target} \
+		--prefix="${EPREFIX}"/usr \
+		--openssldir="${EPREFIX}"${SSL_CNF_DIR} \
+		--libdir=$(get_libdir) \
+		${_optflags} \
+		$(use cpu_flags_x86_sse2 || echo "no-sse2") \
+		enable-camellia \
+		enable-ec \
+		enable-ec2m \
+		enable-sm2 \
+		enable-srp \
+		$(use elibc_musl && echo "no-async") \
+		${ec_nistp_64_gcc_128} \
+		enable-idea \
+		enable-mdc2 \
+		enable-rc5 \
+		$(use_ssl weak-ssl-ciphers) \
+		no-tests \
+		$(use_ssl asm) \
+		$(use_ssl rfc3779) \
+		$(use_ssl sctp) \
+		$(use_ssl tls-compression zlib) \
+		$(use_ssl tls-heartbeat heartbeats) \
+		shared threads \
+		|| die
+
+	perl configdata.pm --dump
+}
+
+src_compile() {
+	# depend is needed to use $confopts; it also doesn't matter
+	# that it's -j1 as the code itself serializes subdirs
+	emake -j1 depend
+	emake all
+}
+
+src_install() {
+	# We need to create $ED/usr on our own to avoid a race condition #665130
+	if [[ ! -d "${ED}/usr" ]]; then
+		# We can only create this directory once
+		mkdir "${ED}"/usr || die
+	fi
+
+	emake DESTDIR="${D}" install
+
+	# This is crappy in that the static archives are still built even
+	# when USE=static-libs.  But this is due to a failing in the openssl
+	# build system: the static archives are built as PIC all the time.
+	# Only way around this would be to manually configure+compile openssl
+	# twice; once with shared lib support enabled and once without.
+	if ! use static-libs; then
+		rm "${ED}"/usr/$(get_libdir)/lib{crypto,ssl}.a || die
+	fi
+
+	# Avoid conflicts with sys-apps/shadow
+	rm "${ED}"/usr/share/man/man1/{openssl-passwd,passwd}.* || die
+
+	dodoc AUTHORS CHANGES FAQ NEWS README doc/*.txt doc/${PN}-c-indent.el
+	# create the certs directory
+	keepdir ${SSL_CNF_DIR}/certs
+
+	dodir /etc/sandbox.d #254521
+	echo 'SANDBOX_PREDICT="/dev/crypto"' > "${ED}"/etc/sandbox.d/10openssl
+
+	diropts -m0700
+	keepdir ${SSL_CNF_DIR}/private
+}
+
+pkg_postinst() {
+	ebegin "Running 'openssl rehash ${EROOT}${SSL_CNF_DIR}/certs/' to rebuild hashes #333069"
+	openssl rehash "${EROOT}${SSL_CNF_DIR}/certs" >/dev/null
+	eend $?
+}
+
+# vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package dev-libs/openssl-1.1.1 for branch mark-unstable by mark-bot