### PR TITLE
mark-devkit: [mark-31] Bump sys-auth/elogind-257.16-r1

### DIFF
--- a/sys-auth/elogind/elogind-257.16-r1.ebuild
+++ b/sys-auth/elogind/elogind-257.16-r1.ebuild
@@ -12,7 +12,7 @@ LICENSE="GPL-2.0"
 SLOT="0"
 KEYWORDS="*"
 PATCHES=(
-	"${FILESDIR}/elogind-257.13-nodocs.patch"
+	"${FILESDIR}/elogind-257.16-nodocs.patch"
 )
 IUSE="+acl audit cgroup-hybrid debug doc +pam +policykit"
 BDEPEND="app-text/docbook-xml-dtd:4.2

--- a/sys-auth/elogind/files/elogind-257.16-nodocs.patch
+++ b/sys-auth/elogind/files/elogind-257.16-nodocs.patch
@@ -1,0 +1,10 @@
+--- a/meson.build
++++ b/meson.build
+@@ -3343,7 +3343,6 @@
+ #if 0 /// irrelevant for elogind
+ #              'docs/DISTRO_PORTING.md',
+ #endif // 0
+-             'docs/ENVIRONMENT.md',
+ #if 0 /// irrelevant for elogind
+ #              'docs/HACKING.md',
+ #              'docs/TRANSIENT-SETTINGS.md',


### PR DESCRIPTION
Automatic bump of package sys-auth/elogind-257.16-r1 for branch mark-31 by mark-bot